### PR TITLE
Allow usage of minor PHP versions like 8.2.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "InRiver Adapter for Magento",
   "version": "24.8.1",
   "require": {
-    "php": ">=7.4 <=8.3",
+    "php": "~8.1.*||~8.2.*",
     "magento/module-asynchronous-operations": ">=100.4"
   },
   "type": "magento2-module",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "InRiver Adapter for Magento",
   "version": "24.8.1",
   "require": {
-    "php": ">=7.4 <=8.2.*",
+    "php": ">=7.4 <=8.3",
     "magento/module-asynchronous-operations": ">=100.4"
   },
   "type": "magento2-module",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "InRiver Adapter for Magento",
   "version": "24.8.1",
   "require": {
-    "php": "~8.1.0||~8.2.0",
+    "php": ">=7.4 <=8.2.*",
     "magento/module-asynchronous-operations": ">=100.4"
   },
   "type": "magento2-module",


### PR DESCRIPTION
The current composer.json php requirements doesn't allow to use higher versions of PHP than 8.2.0